### PR TITLE
Add --no-if-modified-since arg to wget call.

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -264,7 +264,7 @@ sub download_urls
 
         if ( $pid == 0 )
         {
-            exec 'wget', '--no-cache', '--limit-rate=' . get_variable("limit_rate"), '-t', '5', '-r', '-N', '-l', 'inf', '-o', get_variable("var_path") . "/$stage-log.$i", '-i', get_variable("var_path") . "/$stage-urls.$i", @args;
+            exec 'wget', '--no-if-modified-since', '--no-cache', '--limit-rate=' . get_variable("limit_rate"), '-t', '5', '-r', '-N', '-l', 'inf', '-o', get_variable("var_path") . "/$stage-log.$i", '-i', get_variable("var_path") . "/$stage-urls.$i", @args;
 
             # shouldn't reach this unless exec fails
             die("\n\nCould not run wget, please make sure its installed and in your path\n\n");


### PR DESCRIPTION
This will cause wget to send a HEAD request allowing
us to check the timestamp and file size.

I tested this by interrupting the transfer, giving us something like
```
--2022-01-30 17:49:31--  http://de.archive.ubuntu.com/ubuntu/pool/main/c/ceph/ceph-base_15.2.1-0ubuntu1_amd64.deb
Reusing existing connection to de.archive.ubuntu.com:80.
HTTP request sent, awaiting response... 200 OK
Length: 5239076 (5,0M) [application/x-debian-package]
Saving to: ‘de.archive.ubuntu.com/ubuntu/pool/main/c/ceph/ceph-base_15.2.1-0ubuntu1_amd64.deb’

     0K .......... .......... .......... .......... ..........  0% 22,8M 0s
    50K .......... .......... .......... .......... ..........  1%  829K 3s
   100K .......... .......... .......... .......... ..........  2%  836K 4s
   150K .......... .......... .......... .......... ..........  3% 9,35M 3s
   200K .......... .......... .......... .......... ..........  4%  829K 4s
   250K .......... .......... .......... .......... ..........  5%  903K 4s
   300K .......... .......... .......... .......... ..........  6% 6,31M 3s
   350K .......... .......... .......... .......... ..........  7%  835K 4s
   400K .......... .......... .......... .......... ..........  8%  811K 4s
   450K .......... .......... .......... .......... ..........  9%  794K 4s
   500K .......... .......... .......... .......... .......... 10% 1,04M 4s
   550K .......... .......... .......... .......... .......... 11%  241M 4s
   600K .......... .......... .......... .......... .......... 12% 1,06M 4s
   650K .......... .......... .......... .......... .......... 13% 1,04M 4s
   700K .......... .......... .......... .......... .......... 14% 1,13M 4s
   750K .......... .......... .......... .......... .......... 15% 1,19M 4s
   800K .......... .......... .......... .......... .......... 16% 1,20M 4s
   850K .......... .......... .......... .......... .......... 17% 1,26M 3s
   900K .......... .......... .......... .......... .......... 18% 1,22M 3s
   950K .......... .......... .......... .......... .......... 19% 2,98M 3s
  1000K .......... .......... .......... .......... .......... 20% 1,16M 3s
  1050K .......... .......... .......... .......... .......... 21% 1,09M 3s
  1100K .......... .......... .......... .......... .......... 22% 1,38M 3s
  1150K .......... .......... .......... .......... .......... 23% 1,06M 3s
  1200K .......... .......... .......... .......... .......... 24% 1,04M 3s
  1250K .......... .......... .......... .......... .......... 25% 1,10M 3s
  1300K .......... .......... .......... .......... .......... 26% 5,44M 3s
  1350K .......... .......... .......... .......... .......... 27% 1,08M 3s
  1400K .......... .......... .......... .......... .......... 28% 1,11M 3s
  1450K .......... .......... .......... .......... .......... 29% 1,04M 3s
  1500K .......... .......... .......... .......... .......... 30% 1,12M 3s
  1550K .......... .......... .......... .......... .......... 31% 2,16M 3s
  1600K .......... .......... .......... .......... .......... 32% 1,21M 3s
  1650K .......... .......... .......... .......... .......... 33%  960K 3s
  1700K .......... .......... .......... ........
^C

```
Examining the downloaded file size yields a truncated file as expected:
```
$ ll mirror/de.archive.ubuntu.com/ubuntu/pool/main/c/ceph/ceph-base_15.2.1-0ubuntu1_amd64.deb
-rw-rw-r-- 1 dk apt-mirror 1780097 Jan 30 17:49 mirror/de.archive.ubuntu.com/ubuntu/pool/main/c/ceph/ceph-base_15.2.1-0ubuntu1_amd64.deb
```
Running the script with the suggested commit again then downloads the rest of the file:
```
$ ll mirror/de.archive.ubuntu.com/ubuntu/pool/main/c/ceph/ceph-base_15.2.1-0ubuntu1_amd64.deb
-rw-rw-r-- 1 dk apt-mirror 5239076 Apr 18  2020 mirror/de.archive.ubuntu.com/ubuntu/pool/main/c/ceph/ceph-base_15.2.1-0ubuntu1_amd64.deb

```
