### PR TITLE
Skip downloading the non-existent uncompressed `Packages` file

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -566,7 +566,9 @@ sub find_metadata_in_release
                             ) or (
                                 $filename =~ m{^${component_regex}/Contents-${arch_regex}${compressed_extension_regex}}
                             ) or (
-                                $filename =~ m{^${component_regex}/binary-${arch_regex}} #Need all files in this folder for netboot.
+                                $filename =~ m{^${component_regex}/binary-${arch_regex}/Packages${compressed_extension_regex}}
+                            ) or (
+                                $filename =~ m{^${component_regex}/binary-${arch_regex}/Release$} # Needed for netboot.
                             ) or (
                                 $filename =~ m{^${component_regex}/cnf/Commands-${arch_regex}${compressed_extension_regex}}
                             ) or (


### PR DESCRIPTION
Let's skip downloading the non-existent uncompressed Packages file as it
is failing 100% of the time anyway.

It seems that the `Release` file under the binary directory is necessary
in some situations, even though it is documented as unnecessary in
https://wiki.debian.org/DebianRepository/Format#Legacy_per-component-and-architecture_Release_files

> Legacy per-component-and-architecture Release files
> Servers may provide legacy Release files in
> "dists/$DIST/$COMP/binary-$ARCH/Release".
>
> It should contain only the following fields:
>
> - Archive (old name for Suite)
> - Origin
> - Label
> - Acquire-By-Hash (optional)
> - Component: $COMP (singular variant of Components)
> - Architecture: $ARCH (current architecture)
>
> Clients must not use them.