### PR TITLE
The debian network installer needs these files too

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -566,9 +566,9 @@ sub find_metadata_in_release
                             ) or (
                                 $filename =~ m{^${component_regex}/Contents-${arch_regex}${compressed_extension_regex}}
                             ) or (
-                                $filename =~ m{^${component_regex}/binary-${arch_regex}/Packages${compressed_extension_regex}}
+                                $filename =~ m{^${component_regex}/(?:debian-installer/)?binary-${arch_regex}/Packages${compressed_extension_regex}}
                             ) or (
-                                $filename =~ m{^${component_regex}/binary-${arch_regex}/Release$} # Needed for netboot.
+                                $filename =~ m{^${component_regex}/(?:debian-installer/)?binary-${arch_regex}/Release$}
                             ) or (
                                 $filename =~ m{^${component_regex}/cnf/Commands-${arch_regex}${compressed_extension_regex}}
                             ) or (
@@ -803,6 +803,8 @@ foreach (@config_binaries)
         {
             process_index( $uri, "/dists/$distribution/$component/binary-$arch/Packages" );
             process_index( $uri, "/dists/$distribution/$component/binary-all/Packages", 1 );
+            process_index( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages", 1 );
+            process_index( $uri, "/dists/$distribution/$component/debian-installer/binary-all/Packages", 1 );
         }
     }
     elsif ($distribution)


### PR DESCRIPTION
Steps to reproduce:

    virt-install --osinfo debianbullseye --memory 1024 --disk size=10 \
      --location http://ftp.debian.org/debian/dists/bullseye/main/installer-amd64/current/images/netboot/debian-installer/amd64/,kernel=linux,initrd=initrd.gz \

The netboot installer will try to:

1. Read the Release file under binary-$arch
2. Download the Packages file under the debian-installer/binary-$arch
3. Download the microdebs which were described in such Package files