### PR TITLE
Revert "The debian network installer needs these files too"

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -566,9 +566,9 @@ sub find_metadata_in_release
                             ) or (
                                 $filename =~ m{^${component_regex}/Contents-${arch_regex}${compressed_extension_regex}}
                             ) or (
-                                $filename =~ m{^${component_regex}/(?:debian-installer/)?binary-${arch_regex}/Packages${compressed_extension_regex}}
+                                $filename =~ m{^${component_regex}/binary-${arch_regex}/Packages${compressed_extension_regex}}
                             ) or (
-                                $filename =~ m{^${component_regex}/(?:debian-installer/)?binary-${arch_regex}/Release$}
+                                $filename =~ m{^${component_regex}/binary-${arch_regex}/Release$} # Needed for netboot.
                             ) or (
                                 $filename =~ m{^${component_regex}/cnf/Commands-${arch_regex}${compressed_extension_regex}}
                             ) or (
@@ -803,8 +803,6 @@ foreach (@config_binaries)
         {
             process_index( $uri, "/dists/$distribution/$component/binary-$arch/Packages" );
             process_index( $uri, "/dists/$distribution/$component/binary-all/Packages", 1 );
-            process_index( $uri, "/dists/$distribution/$component/debian-installer/binary-$arch/Packages", 1 );
-            process_index( $uri, "/dists/$distribution/$component/debian-installer/binary-all/Packages", 1 );
         }
     }
     elsif ($distribution)


### PR DESCRIPTION
This reverts commit 6514286140ae3f585729aa273f356ab239d1726e.

This was already addressed once in the past, sorry for not catching it
on time. Quoting the original commit 408721e8f04f3e250744bcfde5b5caf0e864f1e8

```
The standard way to include the installation components is via the
mirror spec line, e.g.x

deb-amd64 http://us.archive.ubuntu.com/ubuntu wily main restricted universe multiverse main/debian-installer

This is a universal syntax, used by everybody in the same way. I think
it would be better not for apt-mirror to fetch things I didn't ask for,
and to simply continue it's current behavior of doing what it is asked
to do.
```