### PR TITLE
If a file needs to be updated, we can throw away the local copy

### DIFF
--- a/apt-mirror
+++ b/apt-mirror
@@ -793,6 +793,10 @@ sub need_update
 
     return 1 unless ($size);
     return 0 if $size_on_server == $size;
+
+    if ( get_variable("unlink") == 1 )
+        unlink $filename;
+    }
     return 1;
 }
 


### PR DESCRIPTION
This prevents wget from making an extra request to the server to check
if the file needs to be downloaded - we already know that we want to
download it because the size is different.